### PR TITLE
feat: add commitInterval param

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,22 +98,23 @@ with `config.conf.json` and the table `default.kfk_test` will be created and the
 
 
 ## Parameter References
-| Parameter             | Description             | Default           | example                       |
-|-----------------------|-------------------------|-------------------|-------------------------------|
-| kafkaBootstrapServers | kafka bootstrap servers | "127.0.0.1:64103" | "127.0.0.1:9092,127.0.0.2:9092" |
-| kafkaTopic            | kafka topic             | "test"            | "test"                        |
+| Parameter             | Description             | Default             | example                       |
+|-----------------------|-------------------------|---------------------|-------------------------------|
+| kafkaBootstrapServers | kafka bootstrap servers | "127.0.0.1:64103"   | "127.0.0.1:9092,127.0.0.2:9092" |
+| kafkaTopic            | kafka topic             | "test"              | "test"                        |
 | KafkaConsumerGroup    | kafka consumer group    | "kafka-bend-ingest" | "test"                        |
-| mockData              | mock data               | ""                | ""                            |
-| isJsonTransform       | is json transform       | true              | true                          |
-| databendDSN           | databend dsn            | no                | "http://localhost:8000"       |
-| databendTable         | databend table          | no                | "db1.tbl"                     |
-| batchSize             | batch size              | 1000              | 1000                          |
-| batchMaxInterval      | batch max interval      | 30                | 30                            |
-| dataFormat            | data format             | json              | "json"                        |
-| workers               | workers thread number   | 1                 | 1                             |
-| copyPurge             | copy purge              | false             | false                         |
-| copyForce             | copy force              | false             | false                         |
-| DisableVariantCheck   | disable variant check   | false             | false                         |
-| MinBytes              | min bytes               | 1024              | 1024                          |
-| MaxBytes              | max bytes               | 1048576           | 1048576                       |
-| MaxWait               | max wait                | 10                | 10                            |
+| mockData              | mock data               | ""                  | ""                            |
+| isJsonTransform       | is json transform       | true                | true                          |
+| databendDSN           | databend dsn            | no                  | "http://localhost:8000"       |
+| databendTable         | databend table          | no                  | "db1.tbl"                     |
+| batchSize             | batch size              | 1000                | 1000                          |
+| batchMaxInterval      | batch max interval      | 30                  | 30                            |
+| dataFormat            | data format             | json                | "json"                        |
+| workers               | workers thread number   | 1                   | 1                             |
+| copyPurge             | copy purge              | false               | false                         |
+| copyForce             | copy force              | false               | false                         |
+| DisableVariantCheck   | disable variant check   | false               | false                         |
+| MinBytes              | min bytes               | 1024                | 1024                          |
+| MaxBytes              | max bytes               | 1048576             | 1048576                       |
+| MaxWait               | max wait                | 10                  | 10                            |
+| CommitInterval        | commit interval         | 0                   | 1                             |

--- a/batch_reader.go
+++ b/batch_reader.go
@@ -77,6 +77,7 @@ func NewKafkaBatchReader(cfg *config.Config) *KafkaBatchReader {
 		MaxBytes:         cfg.MaxBytes,
 		ReadBatchTimeout: 2 * time.Duration(cfg.BatchMaxInterval) * time.Second,
 		MaxWait:          time.Duration(cfg.MaxWait) * time.Second,
+		CommitInterval:   time.Duration(cfg.CommitInterval) * time.Second,
 	})
 	return &KafkaBatchReader{
 		batchSize:        cfg.BatchSize,

--- a/config/conf.json
+++ b/config/conf.json
@@ -15,5 +15,6 @@
   "disableVariantCheck": true,
   "minBytes": 1024,
   "maxBytes": 1048576,
-  "maxWait": 10
+  "maxWait": 10,
+  "commitInterval": 1
 }

--- a/config/config.go
+++ b/config/config.go
@@ -41,6 +41,13 @@ type Config struct {
 	//
 	// Default: 10s
 	MaxWait int `json:"maxWait" default:"10"`
+	// CommitInterval indicates the interval at which offsets are committed to
+	// the broker.  If 0, commits will be handled synchronously.
+	//
+	// Default: 0
+	//
+	// Only used when GroupID is set
+	CommitInterval int `json:"commitInterval" default:"0"`
 }
 
 func LoadConfig() (*Config, error) {


### PR DESCRIPTION
By default, CommitMessages will synchronously commit offsets to Kafka. For improved performance, you can instead periodically commit offsets to Kafka by setting CommitInterval on the ReaderConfig.