### PR TITLE
fix: do not exist when kafka context canceled

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.dll
 *.so
 *.dylib
+*.log
 
 # Test binary, built with `go test -c`
 *.test

--- a/config/conf.json
+++ b/config/conf.json
@@ -6,7 +6,7 @@
   "isJsonTransform": true,
   "databendDSN": "https://cloudapp:password@tn3ftqihs--medium-p8at.gw.aws-us-east-2.default.databend.com:443",
   "databendTable": "default.kfk_test",
-  "batchSize": 1,
+  "batchSize": 10,
   "batchMaxInterval": 5,
   "dataFormat": "json",
   "workers": 1,

--- a/consume_worker_test.go
+++ b/consume_worker_test.go
@@ -136,7 +136,7 @@ func TestConsumeKafka(t *testing.T) {
 	ig := NewDatabendIngester(cfg)
 	w := NewConsumeWorker(cfg, "worker1", ig)
 	log.Printf("start consume")
-	w.stepBatch(context.TODO())
+	w.stepBatch()
 
 	result, err := db.Query("select * from test_ingest")
 	assert.NoError(t, err)
@@ -192,7 +192,7 @@ func TestConsumerWithoutTransform(t *testing.T) {
 	}
 	w := NewConsumeWorker(cfg, "worker1", ig)
 	log.Printf("start consume")
-	err = w.stepBatch(context.TODO())
+	err = w.stepBatch()
 	assert.NoError(t, err)
 
 	result, err := db.Query("select * from test_ingest_raw")


### PR DESCRIPTION
Only exist when program receive system signal. And add back off retry when fetch and commit message.